### PR TITLE
Remove Dashboard button and redirect Sign In to login page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,10 +1,8 @@
 import { useState } from 'react'
 import './App.css'
-import LoginModal from './components/LoginModal.jsx'
 import SignupModal from './components/SignupModal.jsx'
 
 function App() {
-  const [showLogin, setShowLogin] = useState(false)
   const [showSignup, setShowSignup] = useState(false)
 
   return (
@@ -18,7 +16,7 @@ function App() {
             </div>
             <div className="flex items-center space-x-4">
               <button 
-                onClick={() => setShowLogin(true)}
+                onClick={() => window.location.href = 'https://app.thelabelai.com/login'}
                 className="text-white hover:text-orange-500 transition-colors"
               >
                 Sign In
@@ -28,12 +26,6 @@ function App() {
                 className="bg-orange-500 hover:bg-orange-600 text-white px-6 py-2 rounded-lg transition-colors"
               >
                 GET STARTED FREE
-              </button>
-              <button 
-                onClick={() => window.location.href = 'https://app.thelabelai.com/dashboard'}
-                className="border border-blue-400 text-blue-400 hover:bg-blue-400 hover:text-white px-4 py-2 rounded-lg transition-colors"
-              >
-                Dashboard
               </button>
             </div>
           </div>
@@ -128,22 +120,13 @@ function App() {
         </div>
       </footer>
 
-      {/* Enhanced Modals */}
-      <LoginModal 
-        isOpen={showLogin}
-        onClose={() => setShowLogin(false)}
-        onSwitchToSignup={() => {
-          setShowLogin(false)
-          setShowSignup(true)
-        }}
-      />
-      
+      {/* Signup Modal */}
       <SignupModal 
         isOpen={showSignup}
         onClose={() => setShowSignup(false)}
         onSwitchToLogin={() => {
           setShowSignup(false)
-          setShowLogin(true)
+          window.location.href = 'https://app.thelabelai.com/login'
         }}
       />
     </div>
@@ -151,4 +134,3 @@ function App() {
 }
 
 export default App
-


### PR DESCRIPTION
## Changes
- Removed redundant Dashboard button from header
- Updated Sign In button to redirect to app.thelabelai.com/login instead of opening modal
- Removed LoginModal component usage (now using dashboard's professional login page)
- Kept only Sign In and GET STARTED FREE buttons in header

## Rationale
- The dashboard's login page (app.thelabelai.com/login) provides a better, more professional sign-in experience
- Having both Dashboard and Sign In buttons was redundant as they both lead to authentication
- Simplifies the header navigation and improves user experience

## Testing
- ✅ Sign In button redirects to dashboard login page
- ✅ GET STARTED FREE button still opens signup modal
- ✅ Header is cleaner with only two action buttons